### PR TITLE
Make sure the link points to the right GitHub repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Easy to use universal dynamic routes for Next.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/elliottsj/next-routes.js.git"
+    "url": "git+https://github.com/yolk-hq/next-routes.git"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
I've just noticed the links on [@yolkai/next-routes NPM page](https://www.npmjs.com/package/@yolkai/next-routes) are pointing to a wrong (probably renamed?) GitHub repo.